### PR TITLE
Update package lock with entries for ngRx packages

### DIFF
--- a/APM-Demo0/package-lock.json
+++ b/APM-Demo0/package-lock.json
@@ -367,6 +367,11 @@
         "tslib": "^1.9.0"
       }
     },
+    "@ngrx/store": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@ngrx/store/-/store-6.0.1.tgz",
+      "integrity": "sha512-cSgfT8CgpOr6BOQac9M3DH6QQC5gxCVjdEcZH//Zn/kwdse86X73iK7KWv6B6AiIEdyVbFfggXNZwd/HiyLGOA=="
+    },
     "@ngtools/webpack": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-6.0.5.tgz",

--- a/APM-Demo1/package-lock.json
+++ b/APM-Demo1/package-lock.json
@@ -372,6 +372,11 @@
       "resolved": "https://registry.npmjs.org/@ngrx/store/-/store-6.0.1.tgz",
       "integrity": "sha512-cSgfT8CgpOr6BOQac9M3DH6QQC5gxCVjdEcZH//Zn/kwdse86X73iK7KWv6B6AiIEdyVbFfggXNZwd/HiyLGOA=="
     },
+    "@ngrx/store-devtools": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@ngrx/store-devtools/-/store-devtools-6.0.1.tgz",
+      "integrity": "sha512-eZyguQvIltJuhCVgPPR1IyMAztykRuvGalwCH1G2ODWKGZPNrWlJbxVMqzUeSJTBS268RIFIkMTwEDKi/xCQoQ=="
+    },
     "@ngtools/webpack": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-6.0.5.tgz",

--- a/APM-Demo2/package-lock.json
+++ b/APM-Demo2/package-lock.json
@@ -367,6 +367,11 @@
         "tslib": "^1.9.0"
       }
     },
+    "@ngrx/effects": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@ngrx/effects/-/effects-6.0.1.tgz",
+      "integrity": "sha512-YS68D7E1qKbbOIzV6Iyfv6BY3CrTNi8nBgGJ6whTi6f7Y0apXySvNj9aOQyzuJsePWziu6h0uJhy2ZFT/iELyg=="
+    },
     "@ngrx/store": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@ngrx/store/-/store-6.0.1.tgz",


### PR DESCRIPTION
Update package lock with entries for ngRx packages. This is needed since in the course, the students are asked to run '`npm install @ngrx/<package>`'. Without a lock file, the latest (_7.x_) versions are installed, which lead to **errors**.

Students not familiar with how NPM and lock files work, might drop the course, since they are unable to run it.

This PR fixes that by updating the package lock file to ensure that only the (_6.x_) versions are installed.