### PR TITLE
Added return statement to updateProducts method

### DIFF
--- a/APM-Demo4/src/app/products/state/product.effects.ts
+++ b/APM-Demo4/src/app/products/state/product.effects.ts
@@ -31,7 +31,7 @@ export class ProductEffects {
       .pipe(
         ofType(ProductActions.updateProduct),
         concatMap(action =>
-          this.productService.updateProduct(action.product)
+          return this.productService.updateProduct(action.product)
             .pipe(
               map(product => ProductActions.updateProductSuccess({ product })),
               catchError(error => of(ProductActions.updateProductFailure({ error })))


### PR DESCRIPTION
When using the updateProducts method, I got the below error:
```Argument of type '(action: { product: Product; } & TypedAction<"[Product] Update Product">) => void' is not assignable to parameter of type '(value: { product: Product; } & TypedAction<"[Product] Update Product">, index: number) => ObservableInput<any>'.Type 'void' is not assignable to type 'ObservableInput<any>'.ts(2345)```

Adding a `return` statement as shown in code fixed this