### PR TITLE
Assign an id in case all products were removed

### DIFF
--- a/APM-Demo0/src/app/products/product.service.ts
+++ b/APM-Demo0/src/app/products/product.service.ts
@@ -48,7 +48,9 @@ export class ProductService {
   createProduct(product: Product): Observable<Product> {
     const headers = new HttpHeaders({ 'Content-Type': 'application/json' });
     // Product Id must be null for the Web API to assign an Id
-    const newProduct = { ...product, id: null };
+    // in case other products exist, in case all products are removed, an id different than null must be set
+    let productId = this.products.length===0? 1 : null;
+    const newProduct = { ...product, id: productId };
     return this.http.post<Product>(this.productsUrl, newProduct, { headers })
       .pipe(
         tap(data => console.log('createProduct: ' + JSON.stringify(data))),

--- a/APM-Demo1/src/app/products/product.service.ts
+++ b/APM-Demo1/src/app/products/product.service.ts
@@ -48,7 +48,9 @@ export class ProductService {
   createProduct(product: Product): Observable<Product> {
     const headers = new HttpHeaders({ 'Content-Type': 'application/json' });
     // Product Id must be null for the Web API to assign an Id
-    const newProduct = { ...product, id: null };
+    // in case other products exist, in case all products are removed, an id different than null must be set
+    let productId = this.products.length===0? 1 : null;
+    const newProduct = { ...product, id: productId };
     return this.http.post<Product>(this.productsUrl, newProduct, { headers })
       .pipe(
         tap(data => console.log('createProduct: ' + JSON.stringify(data))),

--- a/APM-Demo2/src/app/products/product.service.ts
+++ b/APM-Demo2/src/app/products/product.service.ts
@@ -30,7 +30,9 @@ export class ProductService {
   createProduct(product: Product): Observable<Product> {
     const headers = new HttpHeaders({ 'Content-Type': 'application/json' });
     // Product Id must be null for the Web API to assign an Id
-    const newProduct = { ...product, id: null };
+    // in case other products exist, in case all products are removed, an id different than null must be set
+    let productId = this.products.length===0? 1 : null;
+    const newProduct = { ...product, id: productId };
     return this.http.post<Product>(this.productsUrl, newProduct, { headers })
       .pipe(
         tap(data => console.log('createProduct: ' + JSON.stringify(data))),


### PR DESCRIPTION
After all products are removed, when trying to add a product, a 422 exception appears. 

In case all the products were removed, set the product id to 1, otherwise just let the web API assign an id. 

